### PR TITLE
add wrapper script to run build.sh inside docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# This script is used to convert each of the markdown files into HTML.
+#
+# It has these third-party dependencies:
+#   - discount (2.2.6 or later)
+#   - envsubst (available as part of gettext)
+#
+# If you are unable to install these dependencies locally, you may wish to run
+# the build script via docker. You can do that by calling build_with_docker.sh
+
 # cleanup generated content
 rm -f *.html
 rm -f *.bak
@@ -72,5 +81,3 @@ done
 
 cat template/page_prefix.html | envsubst >> $TARGET
 cat template/suffix.html | envsubst >> $TARGET
-
-

--- a/build_with_docker.sh
+++ b/build_with_docker.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This is a wrapper that executes build.sh inside a docker container which has
+# all of the required third-party dependencies.
+
+script_path="$( cd "$(dirname "$0")" || exit $?; pwd -P )"
+
+docker build -t meiners/epwc -<<EOF
+FROM ubuntu:focal
+RUN apt-get update && apt-get install -y \
+    gettext-base \
+    discount \
+ && rm -rf /var/lib/apt/lists/*
+EOF
+
+docker run \
+  --rm \
+  -v "${script_path}:/src" \
+  -w /src \
+  meiners/epwc \
+  "./build.sh"


### PR DESCRIPTION
It took me quite a while to figure out that 'discount' was the
markdown tool used in the build process. I've added documentation to
build.sh noting what its dependencies are.

I've also provided a wrapper script that provisions a docker container
with the correct dependencies and runs the build script. Hopefully this
will make it easier for others to submit corrections to the text and
rebuild the html files.