### PR TITLE
fix some typos in chapter 6

### DIFF
--- a/06_min_max.html
+++ b/06_min_max.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>6. Ordering, min, and max.</title>
+<title>6. Ordering, min, and max</title>
 <style>
 /* http://jasonm23.github.io/markdown-css-themes/ */
 
@@ -127,8 +127,8 @@ td { vertical-align: top; }
 
 
 
-<a name="L6.-Ordering-2c--min-2c--and-max."></a>
-<h1>6. Ordering, min, and max.</h1>
+<a name="L6.-Ordering-2c--min-2c--and-max"></a>
+<h1>6. Ordering, min, and max</h1>
 
 <a name="Learning-to-design-code"></a>
 <h2>Learning to design code</h2>
@@ -139,7 +139,7 @@ I want to teach
 you to think so that you could design something equal or better.
 So most of the algorithms we are looking at are in STL,
 but they are not exposed.
-They&rsquo;re beyond what the standard Committee would ever consider.
+They&rsquo;re beyond what the C++ Standard Committee would ever consider.
 You might say, &ldquo;Alex this is a simple problem. Couldn&rsquo;t you show us how
 to build a search engine?&rdquo;
 Not in a class.</p>
@@ -164,7 +164,7 @@ instead of <code>&lt;=</code>?
 It&rsquo;s important to note that this was a choice I made.
 They give you roughly the same universe of things, so you could design
 it around either.
-But, somewhow I felt <code>&lt;</code> is a more fundamental relation.
+But somehow I felt <code>&lt;</code> is a more fundamental relation.
 <code>&lt;</code> requires a little less typing.
 There are other reasons, too.</p>
 
@@ -180,10 +180,10 @@ It&rsquo;s guaranteed.</p>
 
 <p><strong>Axiom 4:</strong> If <code>a != b</code> then <code>a &lt; b</code> or <code>b &gt; a</code>.</p>
 
-<p>This is also called the trichomoty law,
+<p>This is also called the trichotomy law,
 because for all elements, exactly one of three things must be true<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup>:</p>
 
-<pre><code>(a &lt; b) or (b &lt; a) or (a = b)
+<pre><code>(a &lt; b) or (b &lt; a) or (a == b)
 </code></pre>
 
 <p>There is a fundamental connection between <code>&lt;</code> and <code>==</code>.
@@ -259,9 +259,9 @@ and 5 and 3 are literals which are constant.</p>
 
 <p>What should we return when <code>a == b</code>?
 It seems it doesn&rsquo;t matter.
-But, that&rsquo;s the problem.
+But that&rsquo;s the problem.
 Everywhere in programming you do something and it seems to be correct.
-But, you have to think deeply and then you discover a problem.
+But you have to think deeply and then you discover a problem.
 There is nothing little in programming.</p>
 
 <p>Let me construct a proof for you.
@@ -271,7 +271,7 @@ Nothing should be swapped.
 It&rsquo;s a good requirement.</p>
 
 <p>Another requirement is if I sort two things,
-The first guy should be the <code>min</code> afterwards
+the first guy should be the <code>min</code> afterwards
 and the second guy should be the <code>max</code>.
 We agreed that default ordering for sorting should be ascending.
 Zero, one, two, three is natural.
@@ -291,7 +291,7 @@ should return the first. We will see more of this later.</p>
 <p>When you design a function you often think about just this
 function, and ignore how it interacts with other parts of your API.
 Then you discover inconsistencies which can be very subtle but painful.
-There are several profound mistakes in STL
+There are several profound mistakes in STL.
 They are still in the standard, despite all my attempts to change them.
 It&rsquo;s very easy to make a mistake and it&rsquo;s really hard to fix it.</p>
 
@@ -322,7 +322,7 @@ There are two reasons:</p>
 <li><p><strong>Functionality:</strong> Making it a type would allow it to have state. Pointers to functions have no state.</p></li>
 <li><p><strong>Performance:</strong> If we were passing a pointer it would have to do a function call through the pointer.
 The function call has to save and restore registers.
-It&rsquo;s slow especially if it sits inside a loop and is called a gazallion times.</p></li>
+It&rsquo;s slow especially if it sits inside a loop and is called a gazillion times.</p></li>
 </ol>
 
 
@@ -395,7 +395,7 @@ So, the one in the standard is still broken.
 Let us see why.</p>
 
 <p>It seems that <code>max</code> is just <code>min</code> with <code>&gt;</code>.
-So wh do we need it?
+So why do we need it?
 We still want to provide what is convenient for the customer.
 When they think <code>max</code> and go looking for it, it should somehow work.
 But, its a little bit more.</p>
@@ -416,7 +416,7 @@ void sort2(T&amp; a, T&amp; b, Compare cmp) {
 }
 </code></pre>
 
-<p>It&rsquo;s always preferrable to sort in-place because we can obtain a composable
+<p>It&rsquo;s always preferable to sort in-place because we can obtain a composable
 one by first copying, and then applying the in-place algorithm.</p>
 
 <p>Note once again the order of comparison.
@@ -486,7 +486,7 @@ a &lt; b or b &gt;= a
 
 <p>We assume these statements are true,
 but it&rsquo;s not true.
-There are exceptions whic cause enourmous amounts of harm
+There are exceptions which cause enormous amounts of harm
 and break all the laws of equality and ordering.</p>
 
 <pre><code>double x(0.0/0.0);
@@ -559,7 +559,7 @@ But, <code>{ 1, 4 }</code> is not a subset of <code>{ 1, 2, 3 }</code>.
 Neither is <code>{ 1, 2, 3 }</code> a subset of <code>{ 1, 4 }</code>.
 The two elements are incomparable.<a href="#fnref:2" rev="footnote">&#8617;</a></li>
 <li id="fn:3">
-Function objects like this in C++ fulfill
+Function objects like this in C++ fulfil
 the same role as <a href="https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book-Z-H-21.html#%_sec_3.2">closures or lambdas</a>.
 They capture variables or state, and then use them to evaluate the function.
 The main difference is that their saved context is explicit rather

--- a/06_min_max.md
+++ b/06_min_max.md
@@ -1,4 +1,4 @@
-6. Ordering, min, and max.
+6. Ordering, min, and max
 =============================
 
 ## Learning to design code
@@ -9,7 +9,7 @@ I want to teach
 you to think so that you could design something equal or better.
 So most of the algorithms we are looking at are in STL,
 but they are not exposed.
-They're beyond what the standard Committee would ever consider.
+They're beyond what the C++ Standard Committee would ever consider.
 You might say, "Alex this is a simple problem. Couldn't you show us how
 to build a search engine?"
 Not in a class.
@@ -34,7 +34,7 @@ instead of `<=`?
 It's important to note that this was a choice I made.
 They give you roughly the same universe of things, so you could design
 it around either.
-But, somewhow I felt `<` is a more fundamental relation.
+But somehow I felt `<` is a more fundamental relation.
 `<` requires a little less typing.
 There are other reasons, too.
 
@@ -50,10 +50,10 @@ It's guaranteed.
 
 **Axiom 4:** If `a != b` then `a < b` or ` b > a`.
 
-This is also called the trichomoty law,
+This is also called the trichotomy law,
 because for all elements, exactly one of three things must be true[^eop-ordering]:
 
-    (a < b) or (b < a) or (a = b)
+    (a < b) or (b < a) or (a == b)
 
 There is a fundamental connection between `<` and `==`.
 If `!(b < a)` then it must be the case that `b >= a`.
@@ -135,9 +135,9 @@ and 5 and 3 are literals which are constant.
 
 What should we return when `a == b`?
 It seems it doesn't matter.
-But, that's the problem.
+But that's the problem.
 Everywhere in programming you do something and it seems to be correct.
-But, you have to think deeply and then you discover a problem.
+But you have to think deeply and then you discover a problem.
 There is nothing little in programming.
 
 Let me construct a proof for you.
@@ -147,7 +147,7 @@ Nothing should be swapped.
 It's a good requirement.
 
 Another requirement is if I sort two things,
-The first guy should be the `min` afterwards
+the first guy should be the `min` afterwards
 and the second guy should be the `max`.
 We agreed that default ordering for sorting should be ascending.
 Zero, one, two, three is natural. 
@@ -166,7 +166,7 @@ So let's correct it, so we don't swap unless necessary.
 When you design a function you often think about just this
 function, and ignore how it interacts with other parts of your API.
 Then you discover inconsistencies which can be very subtle but painful.
-There are several profound mistakes in STL
+There are several profound mistakes in STL.
 They are still in the standard, despite all my attempts to change them.
 It's very easy to make a mistake and it's really hard to fix it.
 
@@ -195,7 +195,7 @@ There are two reasons:
 
 2. **Performance:** If we were passing a pointer it would have to do a function call through the pointer.
    The function call has to save and restore registers.
-   It's slow especially if it sits inside a loop and is called a gazallion times.
+   It's slow especially if it sits inside a loop and is called a gazillion times.
 
 ## Less than function object
 
@@ -262,7 +262,7 @@ Remember the faster computers get, the slower function calls are.
     Does it matter? 
     Not at all.
 
-[^function-objects]: Function objects like this in C++ fulfill
+[^function-objects]: Function objects like this in C++ fulfil
     the same role as [closures or lambdas][sicp-env].
     They capture variables or state, and then use them to evaluate the function.
     The main difference is that their saved context is explicit rather
@@ -283,7 +283,7 @@ So, the one in the standard is still broken.
 Let us see why.
 
 It seems that `max` is just `min` with `>`.
-So wh do we need it?
+So why do we need it?
 We still want to provide what is convenient for the customer.
 When they think `max` and go looking for it, it should somehow work.
 But, its a little bit more.
@@ -302,7 +302,7 @@ To see how they should all work, let's write `sort2`, which sorts two things.
       }
     }
 
-It's always preferrable to sort in-place because we can obtain a composable
+It's always preferable to sort in-place because we can obtain a composable
 one by first copying, and then applying the in-place algorithm.
 
 Note once again the order of comparison.
@@ -367,7 +367,7 @@ Certain thing should always work, such as the following:
 
 We assume these statements are true, 
 but it's not true.
-There are exceptions whic cause enourmous amounts of harm
+There are exceptions which cause enormous amounts of harm
 and break all the laws of equality and ordering.
 
     double x(0.0/0.0);
@@ -419,6 +419,3 @@ you have to assure that singular values do not appear in your computation.
 ## Final code
 
 - [minmax.h](code/minmax.h)
-
-
-

--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@ td { vertical-align: top; }
  </li>
 </ul>
 <ul>
- <li><a href="06_min_max.html#L6.-Ordering-2c--min-2c--and-max.">6. Ordering, min, and max.</a>
+ <li><a href="06_min_max.html#L6.-Ordering-2c--min-2c--and-max">6. Ordering, min, and max</a>
  <ul>
   <li><a href="06_min_max.html#Learning-to-design-code">Learning to design code</a></li>
   <li><a href="06_min_max.html#Reviewing-Total-Orderings">Reviewing Total Orderings</a></li>


### PR DESCRIPTION
I don't think any of these should be controversial. I removed the full stop from the heading because it wasn't in keeping with any of the other chapter headings.

I noticed that my editor has removed the three empty lines at the bottom of the markdown file. I think it's done that on other chapters I've raised PRs for. If the lines are there intentionally then I can update my settings to stop it happening again.