### PR TITLE
fix item numbering in chapter 8

### DIFF
--- a/08_lisp.html
+++ b/08_lisp.html
@@ -155,7 +155,7 @@ We don&rsquo;t want garbage collection for
 all the algorithms we want to use.
 So we are going to add a 4th operation:</p>
 
-<ol>
+<ol start="4">
 <li><code>free</code>: manually release/free a pair.</li>
 </ol>
 

--- a/08_lisp.md
+++ b/08_lisp.md
@@ -22,8 +22,9 @@ We don't want garbage collection for
 all the algorithms we want to use.
 So we are going to add a 4th operation:
 
-4. `free`: manually release/free a pair.
-
+<ol start="4">
+<li><code>free</code>: manually release/free a pair.</li>
+</ol>
 
 What we want to do is muck around with lists.
 Meaning you can insert items in the middle, change pointers, connect this and that.
@@ -389,5 +390,3 @@ simply by attaching the end of our list to the free list.
 ## Code
 
 - [list_pool.h](code/list_pool.h)
-
-


### PR DESCRIPTION
Currently the [numbered list in chapter 8](https://justinmeiners.github.io/efficient-programming-with-components/08_lisp.html#L8.-Lisp-2d-like-lists) has the incorrect number against the 4th entry, because the markdown processor interprets it as a new list and starts the numbering at 1 again.

There doesn't seem to be any trivial way of marking up the list so that it starts at 4. `discount` doesn't seem to accept the `{:start="4"}`  syntax that you can use with some other markdown processors.

This PR resorts to using some inline HTML to solve the problem. I suspect that might be unpalatable, so please feel free to summarily reject it! :-)

A different way of achieving more or less the same effect would be to use inline HTML to generate the list entry manually, like this:
```
&emsp;<span>4.</span> `free`: manually release/free a pair.</br>
```

It works... but it's probably less robust to changes in the CSS.

🤷